### PR TITLE
Make dataSource and delegate IBOutlets

### DIFF
--- a/ZLSwipeableView/ZLSwipeableView.h
+++ b/ZLSwipeableView/ZLSwipeableView.h
@@ -38,10 +38,10 @@
 @interface ZLSwipeableView : UIView
 
 ///
-@property (nonatomic, weak) id <ZLSwipeableViewDataSource> dataSource;
+@property (nonatomic, weak) IBOutlet id <ZLSwipeableViewDataSource> dataSource;
 
 ///
-@property (nonatomic, weak) id <ZLSwipeableViewDelegate> delegate;
+@property (nonatomic, weak) IBOutlet id <ZLSwipeableViewDelegate> delegate;
 
 /// Enable this to rotate the views behind the top view. Default to `YES`.
 @property (nonatomic) BOOL isRotationEnabled;


### PR DESCRIPTION
I wanted to set up a ZLSwipeableView using interface builder, and without the delegate and dataSource properties being IBOutlets I have to drop into code to link them up.
